### PR TITLE
gx: update go-multihash

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.4: QmeXm9iwA4cURNmexpuBucDWcV38jNHdqpGcb7yoyP6e4G
+0.0.5: QmShsDUywWAeeUZXzp5EuZg5S94hWxw5C4mwag6NDr7a7e

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     },
     {
       "author": "multiformats",
-      "hash": "QmX3U3YXCQ6UYBxq2LVWF8dARS1hPUTEYLrSx654Qyxyw6",
+      "hash": "QmSGL5Uoa6gKHgBBwQG8u1CWKUC8ZnwaZiLgFVTFBR2bxr",
       "name": "go-multiaddr-net",
-      "version": "1.5.5"
+      "version": "1.5.6"
     },
     {
       "author": "whyrusleeping",
@@ -42,6 +42,6 @@
   "license": "",
   "name": "go-libp2p-nat",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.0.4"
+  "version": "0.0.5"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-peer/pull/20
- https://github.com/libp2p/go-libp2p-secio/pull/23
- https://github.com/multiformats/go-multiaddr/pull/61
- https://github.com/multiformats/go-multiaddr-net/pull/33
- https://github.com/whyrusleeping/iptb/pull/37
- https://github.com/whyrusleeping/mafmt/pull/7
- https://github.com/libp2p/go-libp2p-peerstore/pull/18
- https://github.com/ipfs/go-ipfs-util/pull/6
- https://github.com/libp2p/go-libp2p-transport/pull/25
- https://github.com/libp2p/go-peerstream/pull/19
- https://github.com/libp2p/go-libp2p-loggables/pull/14
- https://github.com/libp2p/go-tcp-transport/pull/17
- https://github.com/libp2p/go-maddr-filter/pull/4
- https://github.com/libp2p/go-ws-transport/pull/28
- https://github.com/libp2p/go-addr-util/pull/9
- https://github.com/ipfs/go-cid/pull/39
- https://github.com/libp2p/go-testutil/pull/15
- https://github.com/libp2p/go-libp2p-interface-conn/pull/4
- https://github.com/libp2p/go-libp2p-interface-pnet/pull/6
- https://github.com/libp2p/go-libp2p-conn/pull/21
- https://github.com/libp2p/go-libp2p-net/pull/15
- https://github.com/libp2p/go-libp2p-metrics/pull/7
- https://github.com/libp2p/go-libp2p-interface-connmgr/pull/2
- https://github.com/libp2p/go-libp2p-host/pull/10
- https://github.com/libp2p/go-libp2p-swarm/pull/46


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace