### PR TITLE
Add the ability to map ports with external port specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,6 @@
   },
   "gxDependencies": [
     {
-      "author": "fd",
-      "hash": "QmPfFaAVvKzacBFh2UBqUzczkPNQxGcLyAXKKD1hjC22re",
-      "name": "go-nat",
-      "version": "1.0.0"
-    },
-    {
       "hash": "QmRREK2CAZ5Re2Bd9zZFG6FeYDppUWt5cMgsoUEp3ktgSr",
       "name": "go-log",
       "version": "1.5.5"
@@ -41,6 +35,12 @@
       "hash": "QmYmsdtJ3HsodkePE3eU3TsCaP2YvPZJ4LoXnNkDE5Tpt7",
       "name": "go-multiaddr",
       "version": "1.3.0"
+    },
+    {
+      "author": "can",
+      "hash": "QmexARa8NULd7ez46u2XeLaLykPvhbVvhxJAJahwXVQKym",
+      "name": "go-nat",
+      "version": "0.0.0"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
Changed the dependency from `github.com/fd/go-nat` to my forked version. I think it's better to fork `go-nat` under `libp2p`
