### PR TITLE
dep: update go-nat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ require (
 	github.com/ipfs/go-log v0.0.1
 	github.com/jbenet/go-cienv v0.0.0-20150120210510-1bb1476777ec // indirect
 	github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8
-	github.com/libp2p/go-nat v0.0.2
+	github.com/libp2p/go-nat v0.0.3
 	github.com/whyrusleeping/go-notifier v0.0.0-20170827234753-097c5d47330f
 )

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b h1:wxtKgYHEncAU00muMD06dzLiahtGM1eouRNOzVV7tdQ=
 github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
-github.com/libp2p/go-nat v0.0.2 h1:wtMkB7RTp9d0NT9jXfMbdhQI7HOJrV8roPMg4WmahbI=
-github.com/libp2p/go-nat v0.0.2/go.mod h1:88nUEt0k0JD45Bk93NIwDqjlhiOwOoV36GchpcVc1yI=
+github.com/libp2p/go-nat v0.0.3 h1:l6fKV+p0Xa354EqQOQP+d8CivdLM4kl5GxC1hSc/UeI=
+github.com/libp2p/go-nat v0.0.3/go.mod h1:88nUEt0k0JD45Bk93NIwDqjlhiOwOoV36GchpcVc1yI=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-isatty v0.0.5 h1:tHXDdz1cpzGaovsTB+TVB8q90WEokoVmfMqoVcrLUgw=


### PR DESCRIPTION
This reverts the change where we were explicitly trying to match the internal port to the external port. Unfortunately, we really want a truly _random_ port as not all NATs handle conflicts gracefully.